### PR TITLE
NEX-865

### DIFF
--- a/api/k8s/deployment.yaml
+++ b/api/k8s/deployment.yaml
@@ -37,13 +37,17 @@ spec:
               value: '32507'
             - name: OPENSTACK_ENDPOINT
               value: "http://192.168.1.14"
+            - name: OPENSTACK_USERDOMAIN
+              value: "default"
             - name: OPENSTACK_USERNAME
               value: "admin"
             - name: OPENSTACK_PASSWORD
               value: "0000"
+            - name: OPENSTACK_KEYSTONEPORT
+              value: "80"
             - name: OPENSTACK_SENLINPORT
               value: "8778"
             - name: OPENSTACK_NEUTRONPORT
               value: "9696"
-            - name: OPENSTACK_USERDOMAIN
-              value: "default"
+            - name: OPENSTACK_NOVAPORT
+              value: "80"

--- a/api/src/main/java/com/nexcloud/api/client/OpenstackClient.java
+++ b/api/src/main/java/com/nexcloud/api/client/OpenstackClient.java
@@ -57,22 +57,22 @@ public class OpenstackClient {
                 HttpEntity<String> request = new HttpEntity<>(headers);
 
                 response = restTemplate.exchange(targetUrl, HttpMethod.GET, request, String.class);
-                LOGGER.info("STATUS CODE: " + response.getStatusCodeValue());
-                LOGGER.info("CACHED TOKEN: " + tokenCache.get(getTokenCacheKey(projectName, domainId)));
-                LOGGER.info("Success");
+                LOGGER.debug("STATUS CODE: " + response.getStatusCodeValue());
+                LOGGER.debug("CACHED TOKEN: " + tokenCache.get(getTokenCacheKey(projectName, domainId)));
+                LOGGER.debug("Success");
 
                 return response;
             } catch (HttpClientErrorException he) {
-                LOGGER.info("HttpClientErrorException getStatusCode : {}", he.getStatusCode());
-                LOGGER.info("HttpClientErrorException getResponseBodyAsString : {}", he.getResponseBodyAsString());
+                LOGGER.debug("HttpClientErrorException getStatusCode : {}", he.getStatusCode());
+                LOGGER.debug("HttpClientErrorException getResponseBodyAsString : {}", he.getResponseBodyAsString());
 
                 if (he.getStatusCode().equals(HttpStatus.UNAUTHORIZED)) {
                     // 캐싱되어있는 토큰이 만료되었다면 토큰을 새로 받아서 tokenCache에 저장한다
                     getAuthenticationToken(projectName, domainId);
-                    LOGGER.info("TokenCache update done");
+                    LOGGER.debug("TokenCache update done");
 
                     if (areValidTokenParameters(projectName, domainId)) {
-                        LOGGER.info("**CACHED TOKEN: " + tokenCache.get(getTokenCacheKey(projectName, domainId)));
+                        LOGGER.debug("**CACHED TOKEN: " + tokenCache.get(getTokenCacheKey(projectName, domainId)));
                         continue;
                     }
                 }

--- a/api/src/main/java/com/nexcloud/api/client/OpenstackClient.java
+++ b/api/src/main/java/com/nexcloud/api/client/OpenstackClient.java
@@ -70,8 +70,11 @@ public class OpenstackClient {
                     // 캐싱되어있는 토큰이 만료되었다면 토큰을 새로 받아서 tokenCache에 저장한다
                     getAuthenticationToken(projectName, domainId);
                     LOGGER.info("TokenCache update done");
-                    LOGGER.info("**CACHED TOKEN: " + tokenCache.get(getTokenCacheKey(projectName, domainId)));
-                    continue;
+
+                    if (areValidTokenParameters(projectName, domainId)) {
+                        LOGGER.info("**CACHED TOKEN: " + tokenCache.get(getTokenCacheKey(projectName, domainId)));
+                        continue;
+                    }
                 }
 
                 he.printStackTrace();
@@ -91,6 +94,10 @@ public class OpenstackClient {
         } // end of for loop
 
         return response;
+    }
+
+    private boolean areValidTokenParameters(String projectName, String domainId) {
+        return tokenCache.get(getTokenCacheKey(projectName, domainId)) != null;
     }
 
     private String checkTokenCacheAndGetToken(String projectName, String domainId) {

--- a/api/src/main/java/com/nexcloud/api/client/OpenstackClient.java
+++ b/api/src/main/java/com/nexcloud/api/client/OpenstackClient.java
@@ -46,9 +46,10 @@ public class OpenstackClient {
         restTemplate.getMessageConverters().add(new StringHttpMessageConverter());
 
         ResponseEntity<String> response = null;
-        for (int cnt = 0; cnt < RETRY_CNT; ++cnt) {
-            try {
 
+        for (int cnt = 0; cnt < RETRY_CNT; ++cnt) {
+
+            try {
                 HttpHeaders headers = new HttpHeaders();
                 headers.setContentType(MediaType.APPLICATION_JSON);
                 headers.add(AUTH_TOKEN_REQUEST_HEADER_NAME, checkTokenCacheAndGetToken(projectName, domainId));
@@ -56,40 +57,26 @@ public class OpenstackClient {
                 HttpEntity<String> request = new HttpEntity<>(headers);
 
                 response = restTemplate.exchange(targetUrl, HttpMethod.GET, request, String.class);
-                // HttpClientErrorException 발생
-                LOGGER.info("**STATUS CODE: " + response.getStatusCodeValue());
-//
-                LOGGER.info("**CACHED TOKEN: " + tokenCache.get(getTokenCacheKey(projectName, domainId)));
-//
-//                if (response.getStatusCode().equals(HttpStatus.UNAUTHORIZED)) {
-//                    // 캐싱되어있는 토큰이 만료되었다면 토큰을 새로 받아서 tokenCache에 저장한다
-//                    getAuthenticationToken(projectName, domainId);
-//                    LOGGER.info("TokenCache update done");
-//                } else if (response.getStatusCode().is2xxSuccessful()) {
-//                    break;
-//                }
+                LOGGER.info("STATUS CODE: " + response.getStatusCodeValue());
+                LOGGER.info("CACHED TOKEN: " + tokenCache.get(getTokenCacheKey(projectName, domainId)));
+                LOGGER.info("Success");
 
-                LOGGER.debug("Success");
                 return response;
             } catch (HttpClientErrorException he) {
-
-                LOGGER.warn("Request Failed (HttpClientErrorException)", he);
-
                 LOGGER.info("HttpClientErrorException getStatusCode : {}", he.getStatusCode());
-
                 LOGGER.info("HttpClientErrorException getResponseBodyAsString : {}", he.getResponseBodyAsString());
-
-                LOGGER.info("CACHED TOKEN: " + tokenCache.get(getTokenCacheKey(projectName, domainId)));
 
                 if (he.getStatusCode().equals(HttpStatus.UNAUTHORIZED)) {
                     // 캐싱되어있는 토큰이 만료되었다면 토큰을 새로 받아서 tokenCache에 저장한다
                     getAuthenticationToken(projectName, domainId);
                     LOGGER.info("TokenCache update done");
+                    LOGGER.info("**CACHED TOKEN: " + tokenCache.get(getTokenCacheKey(projectName, domainId)));
                     continue;
                 }
 
                 he.printStackTrace();
                 // 401 UNAUTHORIZED 가 아니면 다시 던진다
+                LOGGER.warn("Request Failed (HttpClientErrorException)", he);
                 throw he;
             } catch (RestClientException re) {
                 re.printStackTrace();
@@ -100,7 +87,8 @@ public class OpenstackClient {
                 LOGGER.warn("Request Failed (Exception)", e);
                 throw e;
             }
-        }
+
+        } // end of for loop
 
         return response;
     }

--- a/api/src/main/java/com/nexcloud/api/openstack/controller/OpenstackNovaController.java
+++ b/api/src/main/java/com/nexcloud/api/openstack/controller/OpenstackNovaController.java
@@ -40,14 +40,14 @@ public class OpenstackNovaController {
 
     @ApiOperation("List Servers Detailed")
     @GetMapping("/servers/detail")
-    public ResponseEntity<String> getServers(
+    public ResponseEntity<String> getServersDetail(
             @ApiParam(value = "Project Name (ex) admin", required = true) @QueryParam("projectName") String projectName,
             @ApiParam(value = "Domain ID (ex) default", required = true) @QueryParam("domainId") String domainId
     ) {
         ResponseEntity<String> response;
 
         try {
-            response = service.accessOpenstack(novaPort,"/compute/v2.1/servers/detail", projectName, domainId);
+            response = service.accessOpenstack(novaPort, "/compute/v2.1/servers/detail", projectName, domainId);
         } catch (HttpClientErrorException he) {
             response = new ResponseEntity<>("Client error", he.getStatusCode());
         } catch (Exception e) {

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -13,8 +13,7 @@ server.display-name=nexclipperapi
 #############################################################################
 ############################## Prometheus####################################
 #############################################################################
-#prometheus.endpoint=${PROMETHEUS_ENDPOINT:http://nc-promscale-connector:9201}
-prometheus.endpoint=${PROMETHEUS_ENDPOINT:http://192.168.1.14:9090}
+prometheus.endpoint=${PROMETHEUS_ENDPOINT:http://nc-promscale-connector:9201}
 
 openstack.userdomain=${OPENSTACK_USERDOMAIN:default}
 openstack.endpoint=${OPENSTACK_ENDPOINT:http://192.168.1.14}

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -13,7 +13,8 @@ server.display-name=nexclipperapi
 #############################################################################
 ############################## Prometheus####################################
 #############################################################################
-prometheus.endpoint=${PROMETHEUS_ENDPOINT:http://nc-promscale-connector:9201}
+#prometheus.endpoint=${PROMETHEUS_ENDPOINT:http://nc-promscale-connector:9201}
+prometheus.endpoint=${PROMETHEUS_ENDPOINT:http://192.168.1.14:9090}
 
 openstack.userdomain=${OPENSTACK_USERDOMAIN:default}
 openstack.endpoint=${OPENSTACK_ENDPOINT:http://192.168.1.14}


### PR DESCRIPTION
캐싱되어있는 토큰이 만료된 경우 새로 갱신하지 못하는 이슈의 원인은

response = restTemplate.exchange(targetUrl, HttpMethod.GET, request, String.class);

토큰이 유효하지 않을 경우 exchange 메서드에서 HttpClientErrorException이 바로 터지기 때문이었습니다.


해당 부분 이후에 배치되어있던 토큰 갱신 로직을 catch block으로 옮기고

for loop로 catch block까지 감싸도록 수정했습니다.

잘못되거나 미흡한 부분 있는지 봐주시면 감사하겠습니다.